### PR TITLE
Replaced backticks with $(...) for command substitution.

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -2,7 +2,7 @@
 
 ##############################################################################
 ##
-##  Gradle start up script for UN*X
+##  Gradle start up script for UNIX
 ##
 ##############################################################################
 
@@ -10,16 +10,16 @@
 DEFAULT_JVM_OPTS=""
 
 APP_NAME="Gradle"
-APP_BASE_NAME=`basename "$0"`
+APP_BASE_NAME=$(basename "$0")
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"
 
-warn ( ) {
+warn() {
     echo "$*"
 }
 
-die ( ) {
+die() {
     echo
     echo "$*"
     echo
@@ -30,14 +30,14 @@ die ( ) {
 cygwin=false
 msys=false
 darwin=false
-case "`uname`" in
-  CYGWIN* )
+case "$(uname)" in
+  CYGWIN*)
     cygwin=true
     ;;
-  Darwin* )
+  Darwin*)
     darwin=true
     ;;
-  MINGW* )
+  MINGW*)
     msys=true
     ;;
 esac
@@ -47,17 +47,17 @@ esac
 PRG="$0"
 # Need this for relative symlinks.
 while [ -h "$PRG" ] ; do
-    ls=`ls -ld "$PRG"`
-    link=`expr "$ls" : '.*-> \(.*\)$'`
+    ls=$(ls -ld "$PRG")
+    link=$(expr "$ls" : '.*-> \(.*\)$')
     if expr "$link" : '/.*' > /dev/null; then
         PRG="$link"
     else
-        PRG=`dirname "$PRG"`"/$link"
+        PRG=$(dirname "$PRG")"/$link"
     fi
 done
-SAVED="`pwd`"
-cd "`dirname \"$PRG\"`/" >/dev/null
-APP_HOME="`pwd -P`"
+SAVED=$(pwd)
+cd "$(dirname "$PRG")/" >/dev/null
+APP_HOME=$(pwd -P)
 cd "$SAVED" >/dev/null
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
@@ -78,21 +78,23 @@ location of your Java installation."
     fi
 else
     JAVACMD="java"
-    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+    if ! which java >/dev/null 2>&1; then
+        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
 Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
+    fi
 fi
 
 # Increase the maximum file descriptors if we can.
-if [ "$cygwin" = "false" -a "$darwin" = "false" ] ; then
-    MAX_FD_LIMIT=`ulimit -H -n`
-    if [ $? -eq 0 ] ; then
-        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+if [ "$cygwin" = "false" ] && [ "$darwin" = "false" ] ; then
+    MAX_FD_LIMIT=$(ulimit -H -n)
+    if [ $? -eq 0 ]; then
+        if [ "$MAX_FD" = "maximum" ] || [ "$MAX_FD" = "max" ]; then
             MAX_FD="$MAX_FD_LIMIT"
         fi
-        ulimit -n $MAX_FD
-        if [ $? -ne 0 ] ; then
+        ulimit -n "$MAX_FD"
+        if [ $? -ne 0 ]; then
             warn "Could not set maximum file descriptor limit: $MAX_FD"
         fi
     else
@@ -107,12 +109,12 @@ fi
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin ; then
-    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
-    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
-    JAVACMD=`cygpath --unix "$JAVACMD"`
+    APP_HOME=$(cygpath --path --mixed "$APP_HOME")
+    CLASSPATH=$(cygpath --path --mixed "$CLASSPATH")
+    JAVACMD=$(cygpath --unix "$JAVACMD")
 
     # We build the pattern for arguments to be converted via cygpath
-    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    ROOTDIRSRAW=$(find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null)
     SEP=""
     for dir in $ROOTDIRSRAW ; do
         ROOTDIRS="$ROOTDIRS$SEP$dir"
@@ -120,19 +122,19 @@ if $cygwin ; then
     done
     OURCYGPATTERN="(^($ROOTDIRS))"
     # Add a user-defined pattern to the cygpath arguments
-    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+    if [ -n "$GRADLE_CYGPATTERN" ] ; then
         OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
     fi
     # Now convert the arguments - kludge to limit ourselves to /bin/sh
     i=0
     for arg in "$@" ; do
-        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
-        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+        CHECK=$(echo "$arg" | egrep -c "$OURCYGPATTERN" -)
+        CHECK2=$(echo "$arg" | egrep -c "^-" -) ### Determine if an option
 
-        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
-            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        if [ "$CHECK" -ne 0 ] && [ "$CHECK2" -eq 0 ] ; then
+            eval "args$i=$(cygpath --path --ignore --mixed "$arg")"
         else
-            eval `echo args$i`="\"$arg\""
+            eval "args$i=\"$arg\""
         fi
         i=$((i+1))
     done
@@ -154,7 +156,7 @@ fi
 function splitJvmOpts() {
     JVM_OPTS=("$@")
 }
-eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
+eval splitJvmOpts "$DEFAULT_JVM_OPTS" "$JAVA_OPTS" "$GRADLE_OPTS"
 JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
 
 exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"


### PR DESCRIPTION
Enclosed variables in double quotes to avoid issues with paths containing spaces. Slight refactor of the Cygwin path handling and argument conversion for better readability and robustness.